### PR TITLE
Pass additional options along to NodeExecRunner.

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/exec/NpmExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/exec/NpmExecRunner.groovy
@@ -23,6 +23,8 @@ class NpmExecRunner
         runner.arguments = [this.variant.npmScriptFile] + this.arguments
         runner.environment = this.environment
         runner.workingDir = this.workingDir
+        runner.execOverrides = this.execOverrides
+        runner.ignoreExitValue = this.ignoreExitValue
         return runner.execute()
     }
 }


### PR DESCRIPTION
The `NpmExecRunner` creates a new `NodeExecRunner` in its `doExecute()`
method. It needs to pass all options along for proper configuration.
