### PR TITLE
Issue #26: Allow local npm to override bundled npm.

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/exec/NpmExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/exec/NpmExecRunner.groovy
@@ -19,8 +19,17 @@ class NpmExecRunner
             return run( 'npm', this.arguments )
         }
 
+        def String npmScriptFile = this.variant.npmScriptFile
+        def File localNpm = project.file('node_modules/npm/bin/npm-cli.js')
+
+        // Use locally-installed npm if available
+        if ( localNpm.exists() )
+        {
+           npmScriptFile = localNpm.absolutePath
+        }
+
         def runner = new NodeExecRunner( this.project )
-        runner.arguments = [this.variant.npmScriptFile] + this.arguments
+        runner.arguments = [npmScriptFile] + this.arguments
         runner.environment = this.environment
         runner.workingDir = this.workingDir
         runner.execOverrides = this.execOverrides


### PR DESCRIPTION
After applying this fix, the behavior of the gradle node plugin will match up with the command-line, allowing a project-local npm installation to override the bundled / global installation of npm.
