### PR TITLE
Fix #34: Add node to path for NodeExec.

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/exec/NodeExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/exec/NodeExecRunner.groovy
@@ -1,5 +1,4 @@
 package com.moowork.gradle.node.exec
-
 import org.gradle.api.Project
 import org.gradle.process.ExecResult
 
@@ -17,6 +16,13 @@ class NodeExecRunner
         def exec = 'node'
         if ( this.ext.download )
         {
+            def nodeEnvironment = [:]
+            def nodeBinDirPath = this.variant.nodeBinDir.getAbsolutePath()
+
+            nodeEnvironment << System.getenv()
+            nodeEnvironment['PATH'] = nodeBinDirPath + File.pathSeparator + System.getenv('PATH')
+
+            this.environment = nodeEnvironment
             exec = this.variant.nodeExec
         }
 


### PR DESCRIPTION
- Prepend the node bin directory to the `PATH` in the NodeExecRunner
  for downloaded / managed node installations.

Thanks to @time4tea for the easy reproduction steps and solution code. It was just a matter of putting it in the right place. Let me know if there is a better place to inject the node bin directory in the `PATH`. I am going to try my hand at writing some tests for this in the morning - I should have done that to start with.
