### PR TITLE
fix issue for windows environments, not containing "PATH" but "Path"

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/exec/NodeExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/exec/NodeExecRunner.groovy
@@ -20,7 +20,14 @@ class NodeExecRunner
             def nodeBinDirPath = this.variant.nodeBinDir.getAbsolutePath()
 
             nodeEnvironment << System.getenv()
-            nodeEnvironment['PATH'] = nodeBinDirPath + File.pathSeparator + System.getenv('PATH')
+            // Take care of Windows environments that may contain "Path" OR "PATH" - both existing
+            // possibly (but not in parallel as of now)
+            if (System.getenv('Path') != null) {
+                nodeEnvironment['Path'] = nodeBinDirPath + File.pathSeparator + System.getenv('Path')
+            } else {
+                nodeEnvironment['PATH'] = nodeBinDirPath + File.pathSeparator + System.getenv('PATH')
+            }
+
 
             this.environment = nodeEnvironment
             exec = this.variant.nodeExec

--- a/src/test/groovy/com/moowork/gradle/node/util/PlatformHelperTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/util/PlatformHelperTest.groovy
@@ -28,7 +28,7 @@ class PlatformHelperTest
         'Linux'     | 'x86_64' | 'linux'   | 'x64'  | false
     }
 
-    def "throw exeption if unsupported os"()
+    def "throw exception if unsupported os"()
     {
         given:
         System.setProperty( "os.name", 'SunOS' )


### PR DESCRIPTION
This is a simple bugfix case causing problems on some company environments / setup environments, where IT departments might have setup "Path" instead of "PATH".
So the detection of any existing PATH setup fails due to the case mismatch. As of now, I've not seen any other definitions, so other case-sensitive tests are not considered.

The error case was that Windows was allowing PATH and Path to be existing in parallel causing upcoming scripts to consider one of them for setting up the environment vars.

After integrating this fix, also npm preinstall/postinstall/install - scripts like calling "node install.js" will work in case you don't have a local node environment setup. (for example in a Jenkins enterprise environment) 


