### PR TITLE
Allow 64 bit windows to use the x64 node.exe instead of always using 32bit on Windows

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
@@ -49,7 +49,15 @@ class VariantBuilder
     private String getExeDependency()
     {
         def version = this.ext.version
-        return "org.nodejs:node:${version}@exe"
+        def osArch = PlatformHelper.getOsArch()
+        if (osArch.equals( "x86" ))
+        {
+            return "org.nodejs:node:${version}@exe"
+        }
+        else 
+        {
+            return "org.nodejs:x64/node:${version}@exe"            
+        }
     }
 
     private File getNodeDir( final String osName, final String osArch )

--- a/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
@@ -32,7 +32,7 @@ class VariantBuilderTest
         expect:
         variant != null
         variant.windows
-        variant.exeDependency == 'org.nodejs:node:0.11.1@exe'
+        variant.exeDependency == exeDependency
         variant.tarGzDependency == 'org.nodejs:node:0.11.1:linux-x86@tar.gz'
 
         variant.nodeDir.toString().endsWith( NODE_BASE_PATH + nodeDir )
@@ -42,9 +42,9 @@ class VariantBuilderTest
         variant.npmScriptFile.toString().endsWith( NODE_BASE_PATH + "node-v0.11.1-linux-x86${PS}lib${PS}node_modules${PS}npm${PS}bin${PS}npm-cli.js" )
 
         where:
-        osArch   | nodeDir
-        'x86'    | 'node-v0.11.1-windows-x86'
-        'x86_64' | 'node-v0.11.1-windows-x64'
+        osArch   | nodeDir                    | exeDependency
+        'x86'    | 'node-v0.11.1-windows-x86' | 'org.nodejs:node:0.11.1@exe'
+        'x86_64' | 'node-v0.11.1-windows-x64' | 'org.nodejs:x64/node:0.11.1@exe'
     }
 
     @Unroll

--- a/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
@@ -8,6 +8,12 @@ import spock.lang.Unroll
 class VariantBuilderTest
     extends Specification
 {
+
+    /* OS dependant line separator */
+    static final String PS = File.separator
+    /* Relative base path for nodejs installation */
+    static final String NODE_BASE_PATH = "${PS}.gradle${PS}node${PS}"
+
     @Unroll
     def "test variant on windows (#osArch)"()
     {
@@ -28,11 +34,12 @@ class VariantBuilderTest
         variant.windows
         variant.exeDependency == 'org.nodejs:node:0.11.1@exe'
         variant.tarGzDependency == 'org.nodejs:node:0.11.1:linux-x86@tar.gz'
-        variant.nodeDir.toString().endsWith( '/.gradle/node/' + nodeDir )
-        variant.nodeBinDir.toString().endsWith( '/.gradle/node/' + nodeDir + '/bin' )
-        variant.nodeExec.toString().endsWith( '/.gradle/node/' + nodeDir + '/bin/node.exe' )
-        variant.npmDir.toString().endsWith( '/.gradle/node/node-v0.11.1-linux-x86/lib/node_modules' )
-        variant.npmScriptFile.toString().endsWith( '/.gradle/node/node-v0.11.1-linux-x86/lib/node_modules/npm/bin/npm-cli.js' )
+
+        variant.nodeDir.toString().endsWith( NODE_BASE_PATH + nodeDir )
+        variant.nodeBinDir.toString().endsWith( NODE_BASE_PATH + nodeDir + PS + 'bin' )
+        variant.nodeExec.toString().endsWith( NODE_BASE_PATH + nodeDir + PS + "bin${PS}node.exe" )
+        variant.npmDir.toString().endsWith( NODE_BASE_PATH + "node-v0.11.1-linux-x86${PS}lib${PS}node_modules" )
+        variant.npmScriptFile.toString().endsWith( NODE_BASE_PATH + "node-v0.11.1-linux-x86${PS}lib${PS}node_modules${PS}npm${PS}bin${PS}npm-cli.js" )
 
         where:
         osArch   | nodeDir
@@ -59,11 +66,12 @@ class VariantBuilderTest
         !variant.windows
         variant.exeDependency == null
         variant.tarGzDependency == depName
-        variant.nodeDir.toString().endsWith( '/.gradle/node/' + nodeDir )
-        variant.nodeBinDir.toString().endsWith( '/.gradle/node/' + nodeDir + '/bin' )
-        variant.nodeExec.toString().endsWith( '/.gradle/node/' + nodeDir + '/bin/node' )
-        variant.npmDir.toString().endsWith( '/.gradle/node/' + nodeDir + '/lib/node_modules' )
-        variant.npmScriptFile.toString().endsWith( '/.gradle/node/' + nodeDir + '/lib/node_modules/npm/bin/npm-cli.js' )
+
+        variant.nodeDir.toString().endsWith( NODE_BASE_PATH + nodeDir )
+        variant.nodeBinDir.toString().endsWith( NODE_BASE_PATH + nodeDir + PS + 'bin' )
+        variant.nodeExec.toString().endsWith( NODE_BASE_PATH + nodeDir + PS + "bin${PS}node" )
+        variant.npmDir.toString().endsWith( NODE_BASE_PATH + nodeDir + PS + "lib${PS}node_modules" )
+        variant.npmScriptFile.toString().endsWith( NODE_BASE_PATH + nodeDir + PS + "lib${PS}node_modules${PS}npm${PS}bin${PS}npm-cli.js" )
 
         where:
         osName     | osArch   | nodeDir                   | depName


### PR DESCRIPTION
The exeDependency for Windows always pulls in the 32-bit node.exe.  This change will pull in the 64-bit version of node.exe when running 64-bit versions of Windows.  

Note, this also pulls in the earlier commit from abelsromero to fix the VariantBuildTest on windows.