### PR TITLE
Make the plugin compatible with old JVMs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ ext {
     bintrayKey = System.env.'BINTRAY_KEY'
     isMaster = System.env.'TRAVIS_BRANCH' == "master"
     isCI = System.env.'CI'
-    compatibilityVersion = 1.7
+    compatibilityVersion = 1.6
 }
 
 sourceCompatibility = compatibilityVersion


### PR DESCRIPTION
We're using an old JVM (1.6) and I was able to successfully use this plugin by changing compatibilityVersion to 1.6 and rebuilding. 