### PR TITLE
Add configuration point for node_modules location

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ You can configure the plugin using the "node" extension block, like this:
 
       // Set the work directory for unpacking node
       workDir = file("${project.buildDir}/nodejs")
+
+      // Set the work directory where node_modules should be located
+      nodeModulesDir = file("${project.projectDir}")
     }
 
 **Note** that `download` flag is default to `false`. This will change in future versions.

--- a/src/integTest/groovy/com/moowork/gradle/node/NpmInstallTest.groovy
+++ b/src/integTest/groovy/com/moowork/gradle/node/NpmInstallTest.groovy
@@ -32,6 +32,40 @@ class NpmInstallTest
         result.wasUpToDate( 'npmInstall' )
     }
 
+    def 'install packages with npm in different directory'()
+    {
+        when:
+        def packageJson = createFile( 'subdirectory/package.json' )
+        packageJson << """{
+            "name": "example",
+            "dependencies": {
+            }
+        }""".stripIndent()
+
+        this.buildFile << applyPlugin( NodePlugin )
+        this.buildFile << '''
+            node {
+                version = "0.10.33"
+                npmVersion = "2.1.6"
+                download = true
+                workDir = file('build/node')
+                nodeModulesDir = file('subdirectory')
+            }
+        '''.stripIndent()
+
+        def result = runTasksSuccessfully( 'npmInstall' )
+
+        then:
+        !result.wasUpToDate( 'npmInstall' )
+        fileExists( 'subdirectory/node_modules' )
+
+        when:
+        result = runTasksSuccessfully( 'npmInstall' )
+
+        then:
+        result.wasUpToDate( 'npmInstall' )
+    }
+
     def writeEmptyPackageJson()
     {
         def packageJson = createFile( 'package.json', this.projectDir )

--- a/src/main/groovy/com/moowork/gradle/node/NodeExtension.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/NodeExtension.groovy
@@ -10,6 +10,8 @@ class NodeExtension
 
     def File workDir
 
+    def File nodeModulesDir
+
     def String version = '0.11.10'
 
     def String npmVersion = ''
@@ -21,6 +23,7 @@ class NodeExtension
     NodeExtension( final Project project )
     {
         this.workDir = new File( project.gradle.gradleUserHomeDir, 'nodejs' )
+        this.nodeModulesDir = project.projectDir
     }
 
     static NodeExtension get( final Project project )

--- a/src/main/groovy/com/moowork/gradle/node/exec/NpmExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/exec/NpmExecRunner.groovy
@@ -20,7 +20,7 @@ class NpmExecRunner
         }
 
         def String npmScriptFile = this.variant.npmScriptFile
-        def File localNpm = project.file('node_modules/npm/bin/npm-cli.js')
+        def File localNpm = project.file( new File( this.ext.nodeModulesDir, 'node_modules/npm/bin/npm-cli.js' ) )
 
         // Use locally-installed npm if available
         if ( localNpm.exists() )

--- a/src/main/groovy/com/moowork/gradle/node/task/NpmInstallTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/NpmInstallTask.groovy
@@ -15,7 +15,10 @@ class NpmInstallTask
         setNpmCommand('install')
         dependsOn( [NpmSetupTask.NAME] )
 
-        getInputs().file( new File( this.project.getProjectDir(), 'package.json' ) )
-        getOutputs().dir( new File( this.project.getProjectDir(), 'node_modules' ) )
+        this.project.afterEvaluate {
+            getInputs().file( new File( this.project.node.nodeModulesDir, 'package.json' ) )
+            getOutputs().dir( new File( this.project.node.nodeModulesDir, 'node_modules' ) )
+            setWorkingDir( this.project.node.nodeModulesDir )
+        }
     }
 }

--- a/src/main/groovy/com/moowork/gradle/node/task/NpmSetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/NpmSetupTask.groovy
@@ -13,7 +13,11 @@ class NpmSetupTask
         this.group = 'Node'
         this.description = 'Setup a specific version of npm to be used by the build.'
         this.enabled = false
-        getOutputs().dir( new File( this.project.getProjectDir(), 'node_modules/npm' ) )
+
+        this.project.afterEvaluate {
+            getOutputs().dir( new File( this.project.node.nodeModulesDir, 'node_modules/npm' ) )
+            setWorkingDir( this.project.node.nodeModulesDir )
+        }
     }
 
     void configureNpmVersion( String npmVersion )


### PR DESCRIPTION
Add new option in node extension nodeModulesDir.
By default, it is set to the project directory.