### PR TITLE
update node distribution base url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 *.iml
 *.ipr
 .idea
+/out

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ You can configure the plugin using the "node" extension block, like this:
       npmVersion = '2.1.5'
 
       // Base URL for fetching node distributions (change if you have a mirror).
-      distBaseUrl = 'http://nodejs.org/dist'
+      distBaseUrl = 'https://nodejs.org/dist'
 
       // If true, it will download node using above parameters.
       // If false, it will try to use globally installed node.

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     apply from: "$rootDir/gradle/buildscript.gradle", to: buildscript
 }
 
+apply plugin: 'idea'
 apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
@@ -27,4 +28,5 @@ dependencies {
         exclude module: 'groovy-all'
     }
 }
+
 

--- a/src/main/groovy/com/moowork/gradle/node/NodeExtension.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/NodeExtension.groovy
@@ -16,7 +16,7 @@ class NodeExtension
 
     def String npmVersion = ''
 
-    def String distBaseUrl = 'http://nodejs.org/dist'
+    def String distBaseUrl = 'https://nodejs.org/dist'
 
     def String npmCommand = 'npm'
 

--- a/src/test/groovy/com/moowork/gradle/node/NodeExtensionTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/NodeExtensionTest.groovy
@@ -2,7 +2,8 @@ package com.moowork.gradle.node
 
 import nebula.test.ProjectSpec
 import spock.lang.Specification
-
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.DefaultHttpClient
 
 class NodeExtensionTest
     extends ProjectSpec
@@ -21,5 +22,14 @@ class NodeExtensionTest
 
         then:
         this.project.extensions.node.npmCommand == 'npm'
+    }
+
+    def "test nodejs repo base url"()
+    {
+        given:
+        def response = new DefaultHttpClient().execute(new HttpGet(new NodeExtension(this.project).distBaseUrl))
+
+        expect:
+        response.getStatusLine().statusCode == 200
     }
 }

--- a/src/test/groovy/com/moowork/gradle/node/NodePluginTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/NodePluginTest.groovy
@@ -16,4 +16,5 @@ class NodePluginTest
         this.project.tasks.getByName( 'npmInstall' )
         this.project.tasks.getByName( 'npmSetup' )
     }
+
 }


### PR DESCRIPTION
'http://nodejs.org/dist' is replaced by 'https://nodejs.org/dist'

replace #68 

- added test
- fixed readme