### PR TITLE
Handle 4+ nodejs releases on windows

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
@@ -50,13 +50,28 @@ class VariantBuilder
     {
         def version = this.ext.version
         def osArch = PlatformHelper.getOsArch()
-        if (osArch.equals( "x86" ))
+        def majorVersion = version.tokenize('.')[0].toInteger()
+        if ( majorVersion > 3 )
         {
-            return "org.nodejs:node:${version}@exe"
+            if (osArch.equals( "x86" ))
+            {
+                return "org.nodejs:win-x86/node:${version}@exe"
+            }
+            else
+            {
+                return "org.nodejs:win-x64/node:${version}@exe"
+            }
         }
-        else 
+        else
         {
-            return "org.nodejs:x64/node:${version}@exe"            
+            if (osArch.equals( "x86" ))
+            {
+                return "org.nodejs:node:${version}@exe"
+            }
+            else
+            {
+                return "org.nodejs:x64/node:${version}@exe"
+            }
         }
     }
 

--- a/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
@@ -48,6 +48,39 @@ class VariantBuilderTest
     }
 
     @Unroll
+    def "test variant on windows version 4.+ (#osArch)"()
+    {
+        given:
+        def project = ProjectBuilder.builder().build()
+
+        System.setProperty( "os.name", "Windows 8" )
+        System.setProperty( "os.arch", osArch )
+
+        def ext = new NodeExtension( project )
+        ext.version = '4.0.0'
+        ext.workDir = new File( '.gradle/node' ).absoluteFile
+
+        def variant = VariantBuilder.build( ext )
+
+        expect:
+        variant != null
+        variant.windows
+        variant.exeDependency == exeDependency
+        variant.tarGzDependency == 'org.nodejs:node:4.0.0:linux-x86@tar.gz'
+
+        variant.nodeDir.toString().endsWith( NODE_BASE_PATH + nodeDir )
+        variant.nodeBinDir.toString().endsWith( NODE_BASE_PATH + nodeDir + PS + 'bin' )
+        variant.nodeExec.toString().endsWith( NODE_BASE_PATH + nodeDir + PS + "bin${PS}node.exe" )
+        variant.npmDir.toString().endsWith( NODE_BASE_PATH + "node-v4.0.0-linux-x86${PS}lib${PS}node_modules" )
+        variant.npmScriptFile.toString().endsWith( NODE_BASE_PATH + "node-v4.0.0-linux-x86${PS}lib${PS}node_modules${PS}npm${PS}bin${PS}npm-cli.js" )
+
+        where:
+        osArch   | nodeDir                    | exeDependency
+        'x86'    | 'node-v4.0.0-windows-x86'  | 'org.nodejs:win-x86/node:4.0.0@exe'
+        'x86_64' | 'node-v4.0.0-windows-x64'  | 'org.nodejs:win-x64/node:4.0.0@exe'
+    }
+
+    @Unroll
     def "test variant on non-windows (#osName, #osArch)"()
     {
         given:


### PR DESCRIPTION
windows releases have been moves to 'win_x86' and 'win_64' for the
4.0.0 nodejs distributions urls

issue #66 