### PR TITLE
Make NodeTask work a bit more like a regular exec call

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/exec/NodeExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/exec/NodeExecRunner.groovy
@@ -1,5 +1,6 @@
 package com.moowork.gradle.node.exec
 
+import com.moowork.gradle.node.NodeExtension
 import org.gradle.api.Project
 import org.gradle.process.ExecResult
 
@@ -24,7 +25,11 @@ class NodeExecRunner
                 nodeEnvironment << System.getenv()
             }
 
-            def nodeBinDirPath = this.variant.nodeBinDir.getAbsolutePath()
+            String nodeModulesBinPath =
+                    project.extensions.findByType(NodeExtension).nodeModulesDir.absolutePath + '/node_modules/.bin'
+
+            String nodeBinDirPath =
+                    this.variant.nodeBinDir.getAbsolutePath() + File.pathSeparator + nodeModulesBinPath
 
             // Take care of Windows environments that may contain "Path" OR "PATH" - both existing
             // possibly (but not in parallel as of now)

--- a/src/main/groovy/com/moowork/gradle/node/task/NodeTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/NodeTask.groovy
@@ -1,5 +1,6 @@
 package com.moowork.gradle.node.task
 
+import com.moowork.gradle.node.NodeExtension
 import com.moowork.gradle.node.exec.NodeExecRunner
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
@@ -25,6 +26,13 @@ class NodeTask
     void setScript( final File value )
     {
         this.script = value
+    }
+
+    void setExecutable( final String execName )
+    {
+        File modulesDir = project.extensions.findByType(NodeExtension).nodeModulesDir
+        setScript(new File(modulesDir, 'node_modules/.bin/' + execName))
+        dependsOn( NpmInstallTask.NAME )
     }
 
     void setArgs( final Iterable<?> value )


### PR DESCRIPTION
* Add `node_modules/.bin` directory to NodeTask PATH - this ensures that node scripts can call other node scripts properly. With plain grunt / gulp this is rarely an issue, but it's a problem when other tools like cordova and ionic expect to be able to call grunt/gulp themselves.

* Add `executable` field to NodeTask for specifying node scripts directly rather than having to manually depend on the npm install and then constructing the file object from `node_modules/.bin/SCRIPT`, and makes it look more like a normal Exec task.