### PR TITLE
Remove most windows-specific logic around executing npm

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/exec/ExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/exec/ExecRunner.groovy
@@ -33,13 +33,6 @@ abstract class ExecRunner
         def realExec = exec
         def realArgs = args
 
-        if ( this.variant.windows )
-        {
-            realExec = 'cmd'
-            realArgs.add( 0, exec )
-            realArgs = createWinArg( realArgs )
-        }
-
         return this.project.exec( {
             it.executable = realExec
             it.args = realArgs
@@ -64,16 +57,6 @@ abstract class ExecRunner
                 this.execOverrides( it )
             }
         } )
-    }
-
-    private static List<?> createWinArg( final List<?> args )
-    {
-        def result = []
-        args.each {
-            result += '"' + it + '"'
-        }
-
-        return ['/c', '"' + result.join( ' ' ) + '"']
     }
 
     public final ExecResult execute()

--- a/src/main/groovy/com/moowork/gradle/node/exec/NpmExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/exec/NpmExecRunner.groovy
@@ -14,6 +14,10 @@ class NpmExecRunner
     @Override
     protected ExecResult doExecute()
     {
+        if ( this.ext.npmCommand == 'npm' && this.ext.variant.windows ) {
+            this.ext.npmCommand = 'npm.cmd'
+        }
+
         if ( !this.ext.download )
         {
             return run( this.ext.npmCommand, this.arguments )

--- a/src/test/groovy/com/moowork/gradle/node/task/NodeTaskTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/task/NodeTaskTest.groovy
@@ -96,7 +96,8 @@ class NodeTaskTest
         then:
         task.result.exitValue == 0
         1 * this.execSpec.setIgnoreExitValue( false )
-        1 * this.execSpec.setArgs( ['/c', '""node" "' + script.absolutePath + '" "a" "b""'] )
+        1 * this.execSpec.setExecutable( 'node' )
+        1 * this.execSpec.setArgs( [script.absolutePath, 'a', 'b'] )
     }
 
     def "exec node task (windows download)"()

--- a/src/test/groovy/com/moowork/gradle/node/task/NpmTaskTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/task/NpmTaskTest.groovy
@@ -53,8 +53,8 @@ class NpmTaskTest
         task.result.exitValue == 0
         1 * this.execSpec.setIgnoreExitValue( true )
         1 * this.execSpec.setEnvironment( ['a': '1'] )
-        1 * this.execSpec.setExecutable( 'cmd' )
-        1 * this.execSpec.setArgs( ['/c', '""npm" "a" "b""'] )
+        1 * this.execSpec.setExecutable( 'npm.cmd' )
+        1 * this.execSpec.setArgs( ['a', 'b'] )
     }
 
     def "exec npm task (download)"()


### PR DESCRIPTION
This PR basically removes most of the execution logic specific to Windows. It'll now only revert to using the `npm.cmd` file if the OS is Windows. I had great success with this (and tests seems to pass), but I'm totally green in Java/Groovy/Gradle etc. so feedback is welcome if this is totally wrong. It does fix the symptoms mentioned in #64 for me.