### PR TITLE
Implement credentials support for distBaseUrl

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/NodeExtension.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/NodeExtension.groovy
@@ -2,6 +2,9 @@ package com.moowork.gradle.node
 
 import com.moowork.gradle.node.variant.Variant
 import org.gradle.api.Project
+import org.gradle.api.Action
+import org.gradle.api.credentials.Credentials
+import org.gradle.api.artifacts.repositories.PasswordCredentials
 
 class NodeExtension
 {
@@ -16,6 +19,10 @@ class NodeExtension
     def String npmVersion = ''
 
     def String distBaseUrl = 'https://nodejs.org/dist'
+
+    def Action<? super PasswordCredentials> distCredentialsAction = null
+
+    def Class distCredentialsType = PasswordCredentials
 
     def String npmCommand = 'npm'
 
@@ -33,5 +40,42 @@ class NodeExtension
     static NodeExtension get( final Project project )
     {
         return project.extensions.getByType( NodeExtension )
+    }
+
+    void distCredentials( Class credentialsType, Action<? super Credentials> action )
+    {
+        this.distCredentialsType = credentialsType
+        this.distCredentialsAction = action
+    }
+
+    void distCredentials( Action<? super PasswordCredentials> action )
+    {
+        this.distCredentials( this.distCredentialsType, action )
+    }
+
+    class DistCredentials implements PasswordCredentials
+    {
+        def private String username = null
+        def private String password = null
+
+        public String getUsername()
+        {
+            return this.username
+        }
+
+        public String getPassword()
+        {
+            return this.password
+        }
+
+        public void setUsername(String userName)
+        {
+            this.username = userName
+        }
+
+        public void setPassword(String password)
+        {
+            this.password = password
+        }
     }
 }

--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -129,8 +129,12 @@ class SetupTask
             url distUrl
             layout 'pattern', {
                 artifact 'v[revision]/[artifact](-v[revision]-[classifier]).[ext]'
-                ivy 'v[revision]/ivy.xml'
             }
+        }
+
+        if ( this.config.distCredentialsAction != null )
+        {
+            this.repo.credentials( this.config.distCredentialsType, this.config.distCredentialsAction )
         }
     }
 

--- a/src/test/groovy/com/moowork/gradle/node/NodeExtensionTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/NodeExtensionTest.groovy
@@ -1,5 +1,7 @@
 package com.moowork.gradle.node
 
+import org.gradle.api.artifacts.repositories.PasswordCredentials
+
 class NodeExtensionTest
     extends AbstractProjectTest
 {
@@ -13,6 +15,8 @@ class NodeExtensionTest
         ext != null
         ext.npmCommand == 'npm'
         ext.distBaseUrl == 'https://nodejs.org/dist'
+        ext.distCredentialsType == PasswordCredentials
+        ext.distCredentialsAction == null
         ext.workDir != null
         ext.nodeModulesDir != null
         ext.version == '4.4.0'


### PR DESCRIPTION
Closes #126.

I am new to Gradle/Groovy - please let me know if I've made any rookie mistakes. I would've liked to add an integration test for this, but I don't know of a public https://nodejs.org/dist mirror that requires authentication.