### PR TITLE
Update to use Windows zip dists when available

### DIFF
--- a/src/integTest/groovy/com/moowork/gradle/node/Setup_integTest.groovy
+++ b/src/integTest/groovy/com/moowork/gradle/node/Setup_integTest.groovy
@@ -70,8 +70,29 @@ class Setup_integTest
         then:
         result.wasExecuted( 'nodeSetup' )
     }
-
+    
     def 'setup node (windows download)'()
+    {
+        System.setProperty( 'os.name', 'Windows' )
+
+        given:
+        writeBuild( '''
+            apply plugin: 'com.moowork.node'
+
+            node {
+                version = "4.5.0"
+                download = true
+            }
+        ''' )
+
+        when:
+        def result = runTasksSuccessfully( 'nodeSetup' )
+
+        then:
+        result.wasExecuted( 'nodeSetup' )
+    }
+
+    def 'setup node (windows download separate exe)'()
     {
         System.setProperty( 'os.name', 'Windows' )
 

--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -36,7 +36,7 @@ class SetupTask
 
         def set = new HashSet<>()
         set.add( this.config.download )
-        set.add( this.variant.tarGzDependency )
+        set.add( this.variant.archiveDependency )
         set.add( this.variant.exeDependency )
         return set
     }
@@ -65,12 +65,12 @@ class SetupTask
         configureIfNeeded()
         addRepository()
 
-        if ( this.variant.windows )
+        if ( this.variant.exeDependency )
         {
             copyNodeExe()
         }
 
-        unpackNodeTarGz()
+        unpackNodeArchive()
         setExecutableFlag()
         restoreRepositories()
     }
@@ -84,13 +84,20 @@ class SetupTask
         }
     }
 
-    private void unpackNodeTarGz()
+    private void unpackNodeArchive()
     {
-        if ( this.variant.exeDependency )
+        if ( getNodeArchiveFile().getName().endsWith('zip') )
+        {
+            this.project.copy {
+                from this.project.zipTree( getNodeArchiveFile() )
+                into getNodeDir().parent
+            }
+        }
+        else if ( this.variant.exeDependency )
         {
             //Remap lib/node_modules to node_modules (the same directory as node.exe) because that's how the zip dist does it
             this.project.copy {
-                from this.project.tarTree( getNodeTarGzFile() )
+                from this.project.tarTree( getNodeArchiveFile() )
                 into this.variant.nodeBinDir
                 eachFile {
                     def m = it.path =~ /^.*?[\\/]lib[\\/](node_modules.*$)/
@@ -107,7 +114,7 @@ class SetupTask
         else
         {
             this.project.copy {
-                from this.project.tarTree( getNodeTarGzFile() )
+                from this.project.tarTree( getNodeArchiveFile() )
                 into getNodeDir().parent
             }
         }
@@ -126,9 +133,9 @@ class SetupTask
         return resloveSingle( this.variant.exeDependency )
     }
 
-    protected File getNodeTarGzFile()
+    protected File getNodeArchiveFile()
     {
-        return resloveSingle( this.variant.tarGzDependency )
+        return resloveSingle( this.variant.archiveDependency )
     }
 
     private File resloveSingle( String name )

--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -86,9 +86,30 @@ class SetupTask
 
     private void unpackNodeTarGz()
     {
-        this.project.copy {
-            from this.project.tarTree( getNodeTarGzFile() )
-            into getNodeDir().parent
+        if ( this.variant.exeDependency )
+        {
+            //Remap lib/node_modules to node_modules (the same directory as node.exe) because that's how the zip dist does it
+            this.project.copy {
+                from this.project.tarTree( getNodeTarGzFile() )
+                into this.variant.nodeBinDir
+                eachFile {
+                    def m = it.path =~ /^.*?[\\/]lib[\\/](node_modules.*$)/
+                    if (m.matches()) {
+                        // remap the file to the root
+                        it.path = m.group(1)
+                    } else {
+                        it.exclude()
+                    }
+                }
+                includeEmptyDirs = false
+            }
+        }
+        else
+        {
+            this.project.copy {
+                from this.project.tarTree( getNodeTarGzFile() )
+                into getNodeDir().parent
+            }
         }
     }
 

--- a/src/main/groovy/com/moowork/gradle/node/util/PlatformHelper.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/util/PlatformHelper.groovy
@@ -27,7 +27,7 @@ class PlatformHelper
         final String name = property( "os.name" ).toLowerCase()
         if ( name.contains( "windows" ) )
         {
-            return "windows"
+            return "win"
         }
 
         if ( name.contains( "mac" ) )
@@ -80,6 +80,6 @@ class PlatformHelper
 
     public boolean isWindows()
     {
-        return getOsName().equals( "windows" )
+        return getOsName().equals( "win" )
     }
 }

--- a/src/main/groovy/com/moowork/gradle/node/variant/Variant.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/Variant.groovy
@@ -14,7 +14,7 @@ class Variant
 
     def String npmScriptFile
 
-    def String tarGzDependency
+    def String archiveDependency
 
     def String exeDependency
 }

--- a/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
@@ -32,15 +32,22 @@ class VariantBuilder
         if ( variant.windows )
         {
             variant.nodeBinDir = variant.nodeDir
-            variant.tarGzDependency = getTarGzDependency( 'linux', 'x86' )
-            variant.exeDependency = getExeDependency()
+            if (hasWindowsZip())
+            {
+                variant.archiveDependency = getArchiveDependency( osName, osArch, 'zip' )
+            }
+            else
+            {
+                variant.archiveDependency = getArchiveDependency( 'linux', 'x86', 'tar.gz' )
+                variant.exeDependency = getExeDependency()
+            }
             variant.npmDir = new File( variant.nodeBinDir, 'node_modules' )
             variant.nodeExec = new File( variant.nodeBinDir, 'node.exe' ).absolutePath
         }
         else
         {
             variant.nodeBinDir = new File( variant.nodeDir, 'bin' )
-            variant.tarGzDependency = getTarGzDependency( osName, osArch )
+            variant.archiveDependency = getArchiveDependency( osName, osArch, 'tar.gz' )
             variant.npmDir = new File( variant.nodeDir, 'lib/node_modules' )
             variant.nodeExec = new File( variant.nodeBinDir, 'node' ).absolutePath
         }
@@ -49,10 +56,10 @@ class VariantBuilder
         return variant
     }
 
-    private String getTarGzDependency( final String osName, final String osArch )
+    private String getArchiveDependency( final String osName, final String osArch, final String type )
     {
         def version = this.ext.version
-        return "org.nodejs:node:${version}:${osName}-${osArch}@tar.gz"
+        return "org.nodejs:node:${version}:${osName}-${osArch}@${type}"
     }
 
     private String getExeDependency()
@@ -82,6 +89,25 @@ class VariantBuilder
                 return "org.nodejs:x64/node:${version}@exe"
             }
         }
+    }
+
+    //https://github.com/nodejs/node/pull/5995    
+    private boolean hasWindowsZip()
+    {
+        def version = this.ext.version
+        def osArch = platformHelper.getOsArch()
+        def tokens = version.tokenize( '.' );
+        def majorVersion = tokens[0].toInteger()
+        def minorVersion = tokens[1].toInteger()
+        if (
+               ( majorVersion == 4 && minorVersion >= 5 ) // >= 4.5.0
+               || ( majorVersion == 6 && (minorVersion > 2 || (minorVersion == 2 && microVersion >= 1)) ) // >= 6.2.1
+               || majorVersion > 6
+           )
+        {
+            return true
+        }
+        return false
     }
 
     private File getNodeDir( final String osName, final String osArch )

--- a/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
@@ -28,19 +28,20 @@ class VariantBuilder
         def variant = new Variant()
         variant.windows = platformHelper.isWindows()
         variant.nodeDir = getNodeDir( osName, osArch )
-        variant.nodeBinDir = new File( variant.nodeDir, 'bin' )
 
         if ( variant.windows )
         {
+            variant.nodeBinDir = variant.nodeDir
             variant.tarGzDependency = getTarGzDependency( 'linux', 'x86' )
             variant.exeDependency = getExeDependency()
-            variant.npmDir = getNpmDir( 'linux', 'x86' )
+            variant.npmDir = new File( variant.nodeBinDir, 'node_modules' )
             variant.nodeExec = new File( variant.nodeBinDir, 'node.exe' ).absolutePath
         }
         else
         {
+            variant.nodeBinDir = new File( variant.nodeDir, 'bin' )
             variant.tarGzDependency = getTarGzDependency( osName, osArch )
-            variant.npmDir = getNpmDir( osName, osArch )
+            variant.npmDir = new File( variant.nodeDir, 'lib/node_modules' )
             variant.nodeExec = new File( variant.nodeBinDir, 'node' ).absolutePath
         }
 
@@ -88,11 +89,5 @@ class VariantBuilder
         def version = this.ext.version
         def dirName = "node-v${version}-${osName}-${osArch}"
         return new File( this.ext.workDir, dirName )
-    }
-
-    private File getNpmDir( final String osName, final String osArch )
-    {
-        def nodeDir = getNodeDir( osName, osArch )
-        return new File( nodeDir, 'lib/node_modules' )
     }
 }

--- a/src/test/groovy/com/moowork/gradle/node/util/PlatformHelperTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/util/PlatformHelperTest.groovy
@@ -30,8 +30,8 @@ class PlatformHelperTest
 
         where:
         osProp      | archProp | osName    | osArch | isWindows
-        'Windows 8' | 'x86'    | 'windows' | 'x86'  | true
-        'Windows 8' | 'x86_64' | 'windows' | 'x64'  | true
+        'Windows 8' | 'x86'    | 'win' | 'x86'  | true
+        'Windows 8' | 'x86_64' | 'win' | 'x64'  | true
         'Mac OS X'  | 'x86'    | 'darwin'  | 'x86'  | false
         'Mac OS X'  | 'x86_64' | 'darwin'  | 'x64'  | false
         'Linux'     | 'x86'    | 'linux'   | 'x86'  | false

--- a/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
@@ -56,8 +56,8 @@ class VariantBuilderTest
 
         where:
           osArch   | nodeDir                    | exeDependency
-          'x86'    | 'node-v0.11.1-windows-x86' | 'org.nodejs:node:0.11.1@exe'
-          'x86_64' | 'node-v0.11.1-windows-x64' | 'org.nodejs:x64/node:0.11.1@exe'
+          'x86'    | 'node-v0.11.1-win-x86' | 'org.nodejs:node:0.11.1@exe'
+          'x86_64' | 'node-v0.11.1-win-x64' | 'org.nodejs:x64/node:0.11.1@exe'
     }
 
     @Unroll
@@ -91,8 +91,8 @@ class VariantBuilderTest
 
         where:
           osArch   | nodeDir                   | exeDependency
-          'x86'    | 'node-v4.0.0-windows-x86' | 'org.nodejs:win-x86/node:4.0.0@exe'
-          'x86_64' | 'node-v4.0.0-windows-x64' | 'org.nodejs:win-x64/node:4.0.0@exe'
+          'x86'    | 'node-v4.0.0-win-x86' | 'org.nodejs:win-x86/node:4.0.0@exe'
+          'x86_64' | 'node-v4.0.0-win-x64' | 'org.nodejs:win-x64/node:4.0.0@exe'
     }
 
     @Unroll

--- a/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
@@ -48,11 +48,10 @@ class VariantBuilderTest
           variant.tarGzDependency == 'org.nodejs:node:0.11.1:linux-x86@tar.gz'
 
           variant.nodeDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
-          variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + 'bin')
-          variant.nodeExec.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "bin${PS}node.exe")
-          variant.npmDir.toString().endsWith(NODE_BASE_PATH + "node-v0.11.1-linux-x86${PS}lib${PS}node_modules")
-          variant.npmScriptFile.toString().endsWith(
-                  NODE_BASE_PATH + "node-v0.11.1-linux-x86${PS}lib${PS}node_modules${PS}npm${PS}bin${PS}npm-cli.js")
+          variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
+          variant.nodeExec.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node.exe")
+          variant.npmDir.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules")
+          variant.npmScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules${PS}npm${PS}bin${PS}npm-cli.js")
 
         where:
           osArch   | nodeDir                    | exeDependency
@@ -83,11 +82,10 @@ class VariantBuilderTest
           variant.tarGzDependency == 'org.nodejs:node:4.0.0:linux-x86@tar.gz'
 
           variant.nodeDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
-          variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + 'bin')
-          variant.nodeExec.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "bin${PS}node.exe")
-          variant.npmDir.toString().endsWith(NODE_BASE_PATH + "node-v4.0.0-linux-x86${PS}lib${PS}node_modules")
-          variant.npmScriptFile.toString().endsWith(
-                  NODE_BASE_PATH + "node-v4.0.0-linux-x86${PS}lib${PS}node_modules${PS}npm${PS}bin${PS}npm-cli.js")
+          variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
+          variant.nodeExec.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node.exe")
+          variant.npmDir.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules")
+          variant.npmScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules${PS}npm${PS}bin${PS}npm-cli.js")
 
         where:
           osArch   | nodeDir                   | exeDependency

--- a/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
@@ -26,7 +26,7 @@ class VariantBuilderTest
     }
 
     @Unroll
-    def "test variant on windows (#osArch)"()
+    def "test variant on windows version <4 (#osArch)"()
     {
         given:
           def project = ProjectBuilder.builder().build()
@@ -45,7 +45,7 @@ class VariantBuilderTest
           variant != null
           variant.windows
           variant.exeDependency == exeDependency
-          variant.tarGzDependency == 'org.nodejs:node:0.11.1:linux-x86@tar.gz'
+          variant.archiveDependency == 'org.nodejs:node:0.11.1:linux-x86@tar.gz'
 
           variant.nodeDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
           variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
@@ -60,7 +60,7 @@ class VariantBuilderTest
     }
 
     @Unroll
-    def "test variant on windows version 4.+ (#osArch)"()
+    def "test variant on windows version 4.+ with exe (#osArch)"()
     {
         given:
           def project = ProjectBuilder.builder().build()
@@ -79,7 +79,7 @@ class VariantBuilderTest
           variant != null
           variant.windows
           variant.exeDependency == exeDependency
-          variant.tarGzDependency == 'org.nodejs:node:4.0.0:linux-x86@tar.gz'
+          variant.archiveDependency == 'org.nodejs:node:4.0.0:linux-x86@tar.gz'
 
           variant.nodeDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
           variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
@@ -91,6 +91,39 @@ class VariantBuilderTest
           osArch   | nodeDir                   | exeDependency
           'x86'    | 'node-v4.0.0-win-x86' | 'org.nodejs:win-x86/node:4.0.0@exe'
           'x86_64' | 'node-v4.0.0-win-x64' | 'org.nodejs:win-x64/node:4.0.0@exe'
+    }
+    
+    @Unroll
+    def "test variant on windows without exe (#osArch)"()
+    {
+        given:
+          def project = ProjectBuilder.builder().build()
+
+          this.props.setProperty("os.name", "Windows 8")
+          this.props.setProperty("os.arch", osArch)
+
+          def ext = new NodeExtension(project)
+          ext.version = '4.5.0'
+          ext.workDir = new File('.gradle/node').absoluteFile
+
+          def builder = new VariantBuilder(ext)
+          def variant = builder.build()
+
+        expect:
+          variant != null
+          variant.windows
+          variant.exeDependency == null
+          variant.archiveDependency == depName
+
+          variant.nodeDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
+          variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
+          variant.nodeExec.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node.exe")
+          variant.npmDir.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules")
+          variant.npmScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules${PS}npm${PS}bin${PS}npm-cli.js")
+        where:
+          osArch   | nodeDir               |  depName
+          'x86'    | 'node-v4.5.0-win-x86' |  'org.nodejs:node:4.5.0:win-x86@zip'
+          'x86_64' | 'node-v4.5.0-win-x64' |  'org.nodejs:node:4.5.0:win-x64@zip'
     }
 
     @Unroll
@@ -112,7 +145,7 @@ class VariantBuilderTest
           variant != null
           !variant.windows
           variant.exeDependency == null
-          variant.tarGzDependency == depName
+          variant.archiveDependency == depName
 
           variant.nodeDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
           variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + 'bin')
@@ -153,7 +186,7 @@ class VariantBuilderTest
           variant != null
           !variant.windows
           variant.exeDependency == null
-          variant.tarGzDependency == depName
+          variant.archiveDependency == depName
 
           variant.nodeDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
           variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + 'bin')


### PR DESCRIPTION
The node project relatively recently (https://github.com/nodejs/node/pull/5995) added Windows zip distributions, and we can use those instead of using the standalone windows binary and pulling the node_modules from the linux distribution.

This simplifies and makes the resulting node installation structure consistent with what the standard installation is on Windows.

This is backwards compatible because it will cause all existing node installations to be recreated because the directory name changed from e.g. "node-v4.5.0-windows-x64" to "node-v4.5.0-win-x64".
