### PR TITLE
WIP: Adds support for FreeBSD by not downloading the linux version.

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/NodePlugin.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/NodePlugin.groovy
@@ -72,7 +72,9 @@ class NodePlugin
 
     private void configureSetupTask()
     {
-        this.setupTask.setEnabled( this.config.download )
+        if ( this.config.variant.packaged ) {
+            this.setupTask.setEnabled(this.config.download)
+        }
     }
 
     private void configureNpmSetupTask()

--- a/src/main/groovy/com/moowork/gradle/node/util/PlatformHelper.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/util/PlatformHelper.groovy
@@ -40,9 +40,9 @@ class PlatformHelper
             return "linux"
         }
 
-        if ( name.contains( "freebsd" ) )
+        if ( name.contains( "bsd" ) )
         {
-            return "linux"
+            return "bsd"
         }
 
         if ( name.contains( "sunos" ) )
@@ -81,5 +81,12 @@ class PlatformHelper
     public boolean isWindows()
     {
         return getOsName().equals( "windows" )
+    }
+
+    public boolean isPackaged()
+    {
+        // This works fine on BSD if node is already installed.
+        // But since BSD is not Linux installing the Linux version of node does not work.
+        return !getOsName().equals( "bsd" )
     }
 }

--- a/src/main/groovy/com/moowork/gradle/node/variant/Variant.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/Variant.groovy
@@ -4,6 +4,8 @@ class Variant
 {
     def boolean windows
 
+    def boolean packaged
+
     def File nodeDir
 
     def File npmDir

--- a/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
@@ -27,6 +27,7 @@ class VariantBuilder
 
         def variant = new Variant()
         variant.windows = platformHelper.isWindows()
+        variant.packaged = platformHelper.isPackaged()
         variant.nodeDir = getNodeDir( osName, osArch )
         variant.nodeBinDir = new File( variant.nodeDir, 'bin' )
 
@@ -39,7 +40,9 @@ class VariantBuilder
         }
         else
         {
-            variant.tarGzDependency = getTarGzDependency( osName, osArch )
+            if ( variant.isPackaged() ) {
+                variant.tarGzDependency = getTarGzDependency(osName, osArch)
+            }
             variant.npmDir = getNpmDir( osName, osArch )
             variant.nodeExec = new File( variant.nodeBinDir, 'node' ).absolutePath
         }

--- a/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
@@ -128,8 +128,8 @@ class VariantBuilderTest
           'Linux'    | 'x86_64' | 'node-v0.11.1-linux-x64'  | 'org.nodejs:node:0.11.1:linux-x64@tar.gz'
           'Mac OS X' | 'x86'    | 'node-v0.11.1-darwin-x86' | 'org.nodejs:node:0.11.1:darwin-x86@tar.gz'
           'Mac OS X' | 'x86_64' | 'node-v0.11.1-darwin-x64' | 'org.nodejs:node:0.11.1:darwin-x64@tar.gz'
-          'FreeBSD'  | 'x86'    | 'node-v0.11.1-linux-x86'  | 'org.nodejs:node:0.11.1:linux-x86@tar.gz'
-          'FreeBSD'  | 'x86_64' | 'node-v0.11.1-linux-x64'  | 'org.nodejs:node:0.11.1:linux-x64@tar.gz'
+          'FreeBSD'  | 'x86'    | 'node-v0.11.1-bsd-x86'    | null
+          'FreeBSD'  | 'x86_64' | 'node-v0.11.1-bsd-x64'    | null
           'SunOS'    | 'x86'    | 'node-v0.11.1-sunos-x86'  | 'org.nodejs:node:0.11.1:sunos-x86@tar.gz'
           'SunOS'    | 'x86_64' | 'node-v0.11.1-sunos-x64'  | 'org.nodejs:node:0.11.1:sunos-x64@tar.gz'
     }


### PR DESCRIPTION
FreeBSD is not a linux variant and downloading the linux version does not work.
But instead using node from ports works fine, this adds the attribute `packaged` to `Variant` and if `packaged` is `false` ignores the download to attempt to use the local install.