### PR TITLE
Fix missing property exception when using plugin in conjunction with Node 6.x.x on Windows

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
@@ -99,6 +99,7 @@ class VariantBuilder
         def tokens = version.tokenize( '.' );
         def majorVersion = tokens[0].toInteger()
         def minorVersion = tokens[1].toInteger()
+        def microVersion = tokens[2].toInteger()
         if (
                ( majorVersion == 4 && minorVersion >= 5 ) // >= 4.5.0
                || ( majorVersion == 6 && (minorVersion > 2 || (minorVersion == 2 && microVersion >= 1)) ) // >= 6.2.1

--- a/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
@@ -103,11 +103,13 @@ class VariantBuilderTest
           this.props.setProperty("os.arch", osArch)
 
           def ext = new NodeExtension(project)
-          ext.version = '4.5.0'
+          ext.version = version
           ext.workDir = new File('.gradle/node').absoluteFile
 
           def builder = new VariantBuilder(ext)
           def variant = builder.build()
+          def nodeDir = "node-v${version}-${osArch}".toString()
+          def depName = "org.nodejs:node:${version}:${osArch}@zip".toString()
 
         expect:
           variant != null
@@ -121,9 +123,13 @@ class VariantBuilderTest
           variant.npmDir.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules")
           variant.npmScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules${PS}npm${PS}bin${PS}npm-cli.js")
         where:
-          osArch   | nodeDir               |  depName
-          'x86'    | 'node-v4.5.0-win-x86' |  'org.nodejs:node:4.5.0:win-x86@zip'
-          'x86_64' | 'node-v4.5.0-win-x64' |  'org.nodejs:node:4.5.0:win-x64@zip'
+          version | osArch
+          "4.5.0" | "win-x86"
+          "6.2.1" | "win-x86"
+          "7.0.0" | "win-x86"
+          "4.5.0" | "win-x64"
+          "6.2.1" | "win-x64"
+          "7.0.0" | "win-x64"
     }
 
     @Unroll


### PR DESCRIPTION
PR #142  introduced an issue for Windows users. When using in conjunction with a 6.x version of Node, you run into the following error:

```
[00:57:07]* What went wrong:
[00:57:07]A problem occurred evaluating project .
[00:57:07]> A problem occurred configuring project .
[00:57:07]   > No such property: microVersion for class: com.moowork.gradle.node.variant.VariantBuilder
[00:57:07]
[00:57:07]* Try:
[00:57:07]Run with --info or --debug option to get more log output.
[00:57:07]
[00:57:07]* Exception is:
[00:57:07]org.gradle.api.GradleScriptException: A problem occurred evaluating project .
[00:57:07]	at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:92)
[00:57:07]	at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl$2.run(DefaultScriptPluginFactory.java:176)
[00:57:07]	at org.gradle.configuration.ProjectScriptTarget.addConfiguration(ProjectScriptTarget.java:77)
[00:57:07]	at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.apply(DefaultScriptPluginFactory.java:181)
[00:57:07]	at org.gradle.configuration.project.BuildScriptProcessor.execute(BuildScriptProcessor.java:38)
[00:57:07]	at org.gradle.configuration.project.BuildScriptProcessor.execute(BuildScriptProcessor.java:25)
[00:57:07]	at org.gradle.configuration.project.ConfigureActionsProjectEvaluator.evaluate(ConfigureActionsProjectEvaluator.java:34)
[00:57:07]	at org.gradle.configuration.project.LifecycleProjectEvaluator.evaluate(LifecycleProjectEvaluator.java:55)
[00:57:07]	at org.gradle.api.internal.project.DefaultProject.evaluate(DefaultProject.java:573)
[00:57:07]	at org.gradle.api.internal.project.DefaultProject.evaluate(DefaultProject.java:125)
[00:57:07]	at org.gradle.execution.TaskPathProjectEvaluator.configureHierarchy(TaskPathProjectEvaluator.java:47)
[00:57:07]	at org.gradle.execution.TaskSelector.getSelection(TaskSelector.java:84)
[00:57:07]	at org.gradle.execution.TaskSelector.getSelection(TaskSelector.java:75)
[00:57:07]	at org.gradle.execution.commandline.CommandLineTaskParser.parseTasks(CommandLineTaskParser.java:42)
[00:57:07]	at org.gradle.execution.TaskNameResolvingBuildConfigurationAction.configure(TaskNameResolvingBuildConfigurationAction.java:44)
[00:57:07]	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.configure(DefaultBuildConfigurationActionExecuter.java:48)
[00:57:07]	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.access$000(DefaultBuildConfigurationActionExecuter.java:25)
[00:57:07]	at org.gradle.execution.DefaultBuildConfigurationActionExecuter$1.proceed(DefaultBuildConfigurationActionExecuter.java:54)
[00:57:07]	at org.gradle.execution.DefaultTasksBuildExecutionAction.configure(DefaultTasksBuildExecutionAction.java:44)
[00:57:07]	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.configure(DefaultBuildConfigurationActionExecuter.java:48)
[00:57:07]	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.access$000(DefaultBuildConfigurationActionExecuter.java:25)
[00:57:07]	at org.gradle.execution.DefaultBuildConfigurationActionExecuter$1.proceed(DefaultBuildConfigurationActionExecuter.java:54)
[00:57:07]	at org.gradle.execution.ExcludedTaskFilteringBuildConfigurationAction.configure(ExcludedTaskFilteringBuildConfigurationAction.java:47)
[00:57:07]	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.configure(DefaultBuildConfigurationActionExecuter.java:48)
[00:57:07]	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.select(DefaultBuildConfigurationActionExecuter.java:36)
[00:57:07]	at org.gradle.initialization.DefaultGradleLauncher$3.run(DefaultGradleLauncher.java:186)
[00:57:07]	at org.gradle.internal.Factories$1.create(Factories.java:25)
[00:57:07]	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:91)
[00:57:07]	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:53)
[00:57:07]	at org.gradle.initialization.DefaultGradleLauncher.doBuildStages(DefaultGradleLauncher.java:183)
[00:57:07]	at org.gradle.initialization.DefaultGradleLauncher.access$200(DefaultGradleLauncher.java:36)
[00:57:07]	at org.gradle.initialization.DefaultGradleLauncher$1.create(DefaultGradleLauncher.java:118)
[00:57:07]	at org.gradle.initialization.DefaultGradleLauncher$1.create(DefaultGradleLauncher.java:112)
[00:57:07]	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:91)
[00:57:07]	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:63)
[00:57:07]	at org.gradle.initialization.DefaultGradleLauncher.doBuild(DefaultGradleLauncher.java:112)
[00:57:07]	at org.gradle.initialization.DefaultGradleLauncher.run(DefaultGradleLauncher.java:98)
[00:57:07]	at org.gradle.launcher.exec.GradleBuildController.run(GradleBuildController.java:66)
[00:57:07]	at org.gradle.tooling.internal.provider.ExecuteBuildActionRunner.run(ExecuteBuildActionRunner.java:28)
[00:57:07]	at org.gradle.launcher.exec.ChainingBuildActionRunner.run(ChainingBuildActionRunner.java:35)
[00:57:07]	at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:41)
[00:57:07]	at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:26)
[00:57:07]	at org.gradle.tooling.internal.provider.ContinuousBuildActionExecuter.execute(ContinuousBuildActionExecuter.java:75)
[00:57:07]	at org.gradle.tooling.internal.provider.ContinuousBuildActionExecuter.execute(ContinuousBuildActionExecuter.java:49)
[00:57:07]	at org.gradle.tooling.internal.provider.ServicesSetupBuildActionExecuter.execute(ServicesSetupBuildActionExecuter.java:44)
[00:57:07]	at org.gradle.tooling.internal.provider.ServicesSetupBuildActionExecuter.execute(ServicesSetupBuildActionExecuter.java:29)
[00:57:07]	at org.gradle.launcher.cli.RunBuildAction.run(RunBuildAction.java:51)
[00:57:07]	at org.gradle.internal.Actions$RunnableActionAdapter.execute(Actions.java:173)
[00:57:07]	at org.gradle.launcher.cli.CommandLineActionFactory$ParseAndBuildAction.execute(CommandLineActionFactory.java:244)
[00:57:07]	at org.gradle.launcher.cli.CommandLineActionFactory$ParseAndBuildAction.execute(CommandLineActionFactory.java:217)
[00:57:07]	at org.gradle.launcher.cli.JavaRuntimeValidationAction.execute(JavaRuntimeValidationAction.java:33)
[00:57:07]	at org.gradle.launcher.cli.JavaRuntimeValidationAction.execute(JavaRuntimeValidationAction.java:24)
[00:57:07]	at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:33)
[00:57:07]	at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:22)
[00:57:07]	at org.gradle.launcher.cli.CommandLineActionFactory$WithLogging.execute(CommandLineActionFactory.java:210)
[00:57:07]	at org.gradle.launcher.cli.CommandLineActionFactory$WithLogging.execute(CommandLineActionFactory.java:174)
[00:57:07]	at org.gradle.launcher.Main.doAction(Main.java:33)
[00:57:07]	at org.gradle.launcher.bootstrap.EntryPoint.run(EntryPoint.java:45)
[00:57:07]	at org.gradle.launcher.bootstrap.ProcessBootstrap.runNoExit(ProcessBootstrap.java:60)
[00:57:07]	at org.gradle.launcher.bootstrap.ProcessBootstrap.run(ProcessBootstrap.java:37)
[00:57:07]	at org.gradle.launcher.GradleMain.main(GradleMain.java:23)
[00:57:07]	at org.gradle.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:31)
[00:57:07]	at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:108)
[00:57:07]	at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)
```

This is simply the result of a missing local variable referenced in the condition here:
https://github.com/datallah/gradle-node-plugin/blob/e662c636f9426e74268f483f385e7f0d91ea5e2b/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy#L102-L107

I've fixed this error and added test coverage for each of the conditional branches.