### PR TITLE
Add npm/yarn to PATH when executing builds

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/exec/NodeExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/exec/NodeExecRunner.groovy
@@ -6,9 +6,20 @@ import org.gradle.process.ExecResult
 class NodeExecRunner
     extends ExecRunner
 {
+
+    private List<String> pathExtensions = []
+
     public NodeExecRunner( final Project project )
     {
         super( project )
+    }
+
+    public void setPathExtensions(List<String> pathExtensions) {
+      this.pathExtensions = pathExtensions
+    }
+
+    public List<String> getPathExtensions() {
+      return pathExtensions
     }
 
     @Override
@@ -24,17 +35,18 @@ class NodeExecRunner
                 nodeEnvironment << System.getenv()
             }
 
-            def nodeBinDirPath = this.variant.nodeBinDir.getAbsolutePath()
+            def allExtensions = [this.variant.nodeBinDir.getAbsolutePath()] + this.pathExtensions
+            def pathExtension = allExtensions.join(File.pathSeparator)
 
             // Take care of Windows environments that may contain "Path" OR "PATH" - both existing
             // possibly (but not in parallel as of now)
             if ( System.getenv( 'Path' ) != null )
             {
-                nodeEnvironment['Path'] = nodeBinDirPath + File.pathSeparator + System.getenv( 'Path' )
+                nodeEnvironment['Path'] = pathExtension + File.pathSeparator + System.getenv( 'Path' )
             }
             else
             {
-                nodeEnvironment['PATH'] = nodeBinDirPath + File.pathSeparator + System.getenv( 'PATH' )
+                nodeEnvironment['PATH'] = pathExtension + File.pathSeparator + System.getenv( 'PATH' )
             }
 
             this.environment = nodeEnvironment

--- a/src/main/groovy/com/moowork/gradle/node/exec/NodeExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/exec/NodeExecRunner.groovy
@@ -38,13 +38,14 @@ class NodeExecRunner
             def allExtensions = [this.variant.nodeBinDir.getAbsolutePath()] + this.pathExtensions
             def pathExtension = allExtensions.join(File.pathSeparator)
 
+
             // Take care of Windows environments that may contain "Path" OR "PATH" - both existing
             // possibly (but not in parallel as of now)
             if ( System.getenv( 'Path' ) != null )
             {
                 nodeEnvironment['Path'] = pathExtension + File.pathSeparator + System.getenv( 'Path' )
             }
-            else
+            if ( System.getenv( 'PATH' ) != null )
             {
                 nodeEnvironment['PATH'] = pathExtension + File.pathSeparator + System.getenv( 'PATH' )
             }

--- a/src/main/groovy/com/moowork/gradle/node/npm/NpmExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/npm/NpmExecRunner.groovy
@@ -42,6 +42,7 @@ class NpmExecRunner
 
         def runner = new NodeExecRunner( this.project )
         runner.arguments = [npmScriptFile] + this.arguments
+        runner.pathExtensions = [ this.ext.npmWorkDir.getAbsolutePath() ]
         runner.environment = this.environment
         runner.workingDir = this.workingDir
         runner.execOverrides = this.execOverrides

--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -70,10 +70,21 @@ class SetupTask
         {
             copyNodeExe()
         }
+        if ( this.variant.windows )
+        {
+          addBashLauncher()
+        }
 
         unpackNodeArchive()
         setExecutableFlag()
         restoreRepositories()
+    }
+
+    private void addBashLauncher() {
+      File nodeBashLauncher = new File(this.variant.nodeBinDir, 'node')
+      if(!nodeBashLauncher.exists()) {
+            nodeBashLauncher.text = getClass().getClassLoader().getResourceAsStream('node-launcher.sh').text
+      }
     }
 
     private void copyNodeExe()

--- a/src/main/groovy/com/moowork/gradle/node/yarn/YarnExecRunner.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/yarn/YarnExecRunner.groovy
@@ -29,6 +29,7 @@ class YarnExecRunner
         def String yarnScriptFile = "${this.project.node.yarnWorkDir}/node_modules/yarn/bin/yarn.js"
         def runner = new NodeExecRunner( this.project )
         runner.arguments = [yarnScriptFile] + this.arguments
+        runner.pathExtensions = [ this.project.node.yarnWorkDir.getAbsolutePath() ]
         runner.environment = this.environment
         runner.workingDir = this.workingDir
         runner.execOverrides = this.execOverrides

--- a/src/main/resources/node-launcher.sh
+++ b/src/main/resources/node-launcher.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# node launcher provided by gradle-node-plugin
+(set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
+
+basedir=`dirname "$0"`
+
+case `uname` in
+    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+NODE_EXE="$basedir/node.exe"
+if ! [ -x "$NODE_EXE" ]; then
+  NODE_EXE=node
+fi
+
+"$NODE_EXE" "$@"

--- a/src/test/groovy/com/moowork/gradle/node/npm/NpmInstall_integTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/npm/NpmInstall_integTest.groovy
@@ -36,6 +36,42 @@ class NpmInstall_integTest
         result.outcome == TaskOutcome.UP_TO_DATE
     }
 
+    def 'install packages with npm and postinstall task requiring npm and node'()
+    {
+        given:
+        writeBuild( '''
+            plugins {
+                id 'com.moowork.node'
+            }
+
+            node {
+                version = "0.10.33"
+                npmVersion = "2.1.6"
+                download = true
+                workDir = file('build/node')
+            }
+        ''' )
+        writePackageJson(""" {
+            "name": "example",
+            "dependencies": {},
+            "versionOutput" : "node --version",
+            "postinstall" : "npm run versionOutput"
+        }
+        """)
+
+        when:
+        def result = buildTask( 'npmInstall' )
+
+        then:
+        result.outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = buildTask( 'npmInstall' )
+
+        then:
+        result.outcome == TaskOutcome.UP_TO_DATE
+    }
+
     def 'install packages with npm in different directory'()
     {
         given:

--- a/src/test/groovy/com/moowork/gradle/node/yarn/YarnInstall_integTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/yarn/YarnInstall_integTest.groovy
@@ -37,6 +37,43 @@ class YarnInstall_integTest
         result.outcome == TaskOutcome.UP_TO_DATE
     }
 
+    def 'install packages with yarn and and postinstall task requiring node and yarn'()
+    {
+        given:
+        writeBuild( '''
+            plugins {
+                id 'com.moowork.node'
+            }
+
+            node {
+                version = "6.9.1"
+                yarnVersion = "0.16.1"
+                download = true
+                workDir = file('build/node')
+                yarnWorkDir = file('build/yarn')
+            }
+        ''' )
+        writePackageJson(""" {
+            "name": "example",
+            "dependencies": {},
+            "versionOutput" : "node --version",
+            "postinstall" : "yarn run versionOutput"
+        }
+        """)
+
+        when:
+        def result = buildTask( 'yarn' )
+
+        then:
+        result.outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = buildTask( 'yarn' )
+
+        then:
+        result.outcome == TaskOutcome.UP_TO_DATE
+    }
+
     def 'install packages with yarn in different directory'()
     {
         given:


### PR DESCRIPTION
When scripts defined in package.json are run and require npm or yarn to be present on the PATH, they currently fail. This change puts yarn/npm to PATH before execution.
To additionally support execution with GitBash (mingw32) under Windows, a bash launcher script for node is added next to the node.exe.