### PR TITLE
Support using Gradle Build Cache with Yarn tasks

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/yarn/YarnInstallTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/yarn/YarnInstallTask.groovy
@@ -1,5 +1,11 @@
 package com.moowork.gradle.node.yarn
 
+import com.moowork.gradle.node.NodeExtension
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+
 /**
  * yarn install that only gets executed if gradle decides so.*/
 class YarnInstallTask
@@ -13,11 +19,25 @@ class YarnInstallTask
         this.description = 'Install node packages using Yarn.'
         setYarnCommand( '' )
         dependsOn( [YarnSetupTask.NAME] )
+    }
 
-        this.project.afterEvaluate {
-            getInputs().file( new File( (File) this.project.node.nodeModulesDir, 'package.json' ) )
-            getInputs().file( new File( (File) this.project.node.nodeModulesDir, 'yarn.lock' ) )
-            getOutputs().dir( new File( (File) this.project.node.nodeModulesDir, 'node_modules' ) )
-        }
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    protected getPackageJsonFile()
+    {
+        return new File(this.project.extensions.getByType(NodeExtension).nodeModulesDir, 'package.json')
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    protected getYarnLockFile()
+    {
+        return new File(this.project.extensions.getByType(NodeExtension).nodeModulesDir, 'yarn.lock')
+    }
+
+    @OutputDirectory
+    protected getNodeModulesDir()
+    {
+        return new File(this.project.extensions.getByType(NodeExtension).nodeModulesDir, 'node_modules')
     }
 }

--- a/src/main/groovy/com/moowork/gradle/node/yarn/YarnInstallTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/yarn/YarnInstallTask.groovy
@@ -2,6 +2,7 @@ package com.moowork.gradle.node.yarn
 
 import com.moowork.gradle.node.NodeExtension
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -19,20 +20,30 @@ class YarnInstallTask
         this.description = 'Install node packages using Yarn.'
         setYarnCommand( '' )
         dependsOn( [YarnSetupTask.NAME] )
+
+        this.project.afterEvaluate {
+            getInputs().file( new File( (File) this.project.node.nodeModulesDir, 'package.json' ) )
+            getInputs().file( new File( (File) this.project.node.nodeModulesDir, 'yarn.lock' ) )
+            getOutputs().dir( new File( (File) this.project.node.nodeModulesDir, 'node_modules' ) )
+        }
     }
 
     @InputFile
+    @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
     protected getPackageJsonFile()
     {
-        return new File(this.project.extensions.getByType(NodeExtension).nodeModulesDir, 'package.json')
+        def packageJsonFile = new File(this.project.extensions.getByType(NodeExtension).nodeModulesDir, 'package.json')
+        return packageJsonFile.exists() ? packageJsonFile : null
     }
 
     @InputFile
+    @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
     protected getYarnLockFile()
     {
-        return new File(this.project.extensions.getByType(NodeExtension).nodeModulesDir, 'yarn.lock')
+        def lockFile = new File(this.project.extensions.getByType(NodeExtension).nodeModulesDir, 'yarn.lock')
+        return lockFile.exists() ? lockFile : null
     }
 
     @OutputDirectory

--- a/src/main/groovy/com/moowork/gradle/node/yarn/YarnSetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/yarn/YarnSetupTask.groovy
@@ -27,7 +27,6 @@ class YarnSetupTask
         def set = new HashSet<>()
         set.add( this.getConfig().download )
         set.add( this.getConfig().yarnVersion )
-        set.add( this.getConfig().yarnWorkDir )
         return set
     }
 


### PR DESCRIPTION
This pull request enables the ability for users of Yarn install and setup tasks to enable [Gradle Build Cache](https://docs.gradle.org/current/userguide/build_cache.html) support. This relies on relaxing incremental build checking to use only relative path checking so that task outputs creating on one machine (or workspace directory) can be reused somewhere else. Older versions of Gradle will behave the same and ignore `@PathSensitive` annotations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/srs/gradle-node-plugin/205)
<!-- Reviewable:end -->
