### PR TITLE
Support putting cacheDir into rootProject #247

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -37,6 +37,10 @@ buildscript {
 apply plugin: 'com.moowork.node'
 ```
 
+In multi-project builds the plugin can be applied to the individual projects making use of it. By
+further applying it to the root project, child project will make use of the root configuration
+and share a download cache directory.
+ 
 
 ## Installing snapshots
 

--- a/src/main/groovy/com/moowork/gradle/grunt/GruntExtension.groovy
+++ b/src/main/groovy/com/moowork/gradle/grunt/GruntExtension.groovy
@@ -18,4 +18,21 @@ class GruntExtension
     {
         this.workDir = project.projectDir
     }
+
+    static GruntExtension get( final Project project )
+    {
+        return project.extensions.getByType( GruntExtension )
+    }
+
+    static GruntExtension create( final Project project )
+    {
+        def config = project.extensions.create( NAME, GruntExtension, project )
+        if(project.rootProject.hasProperty( GruntExtension.NAME) ){
+            def rootConfig = GruntExtension.get( project.rootProject )
+            config.colors = rootConfig.colors
+            config.bufferOutput = rootConfig.bufferOutput
+            config.gruntFile = rootConfig.gruntFile
+        }
+        return config
+    }
 }

--- a/src/main/groovy/com/moowork/gradle/grunt/GruntPlugin.groovy
+++ b/src/main/groovy/com/moowork/gradle/grunt/GruntPlugin.groovy
@@ -15,7 +15,7 @@ class GruntPlugin
     {
         project.plugins.apply( NodePlugin.class )
 
-        project.extensions.create( GruntExtension.NAME, GruntExtension, project )
+        GruntExtension.create( project )
 
         project.extensions.extraProperties.set( 'GruntTask', GruntTask.class )
         project.tasks.create( GRUNT_INSTALL_NAME, GruntInstallTask.class )

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpExtension.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpExtension.groovy
@@ -16,4 +16,20 @@ class GulpExtension
     {
         this.workDir = project.projectDir
     }
+
+    static GulpExtension get( final Project project )
+    {
+        return project.extensions.getByType( GulpExtension )
+    }
+
+    static GulpExtension create( final Project project )
+    {
+        def config = project.extensions.create( NAME, GulpExtension, project )
+        if(project.rootProject.hasProperty( GulpExtension.NAME) ){
+            def rootConfig = GulpExtension.get( project.rootProject )
+            config.colors = rootConfig.colors
+            config.bufferOutput = rootConfig.bufferOutput
+        }
+        return config
+    }
 }

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpPlugin.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpPlugin.groovy
@@ -15,7 +15,7 @@ class GulpPlugin
     {
         project.plugins.apply( NodePlugin.class )
 
-        project.extensions.create( GulpExtension.NAME, GulpExtension, project )
+        GulpExtension.create( project )
 
         project.extensions.extraProperties.set( 'GulpTask', GulpTask.class )
         project.tasks.create( GULP_INSTALL_NAME, GulpInstallTask.class )

--- a/src/main/groovy/com/moowork/gradle/node/NodeExtension.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/NodeExtension.groovy
@@ -47,6 +47,21 @@ class NodeExtension
 
     static NodeExtension create( final Project project )
     {
-        return project.extensions.create( NAME, NodeExtension, project )
+        def config = project.extensions.create( NAME, NodeExtension, project )
+        if(project.rootProject.hasProperty( NodeExtension.NAME) ){
+            def rootConfig = NodeExtension.get( project.rootProject )
+            config.workDir = rootConfig.workDir
+            config.npmWorkDir = rootConfig.npmWorkDir
+            config.yarnWorkDir = rootConfig.yarnWorkDir
+            config.version = rootConfig.version
+            config.npmVersion = rootConfig.npmVersion
+            config.yarnVersion = rootConfig.yarnVersion
+            config.distBaseUrl = rootConfig.distBaseUrl
+            config.npmCommand = rootConfig.npmCommand
+            config.yarnCommand = rootConfig.yarnCommand
+            config.download = rootConfig.download
+            config.variant = rootConfig.variant
+        }
+        return config
     }
 }

--- a/src/main/groovy/com/moowork/gradle/node/NodePlugin.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/NodePlugin.groovy
@@ -38,9 +38,14 @@ class NodePlugin
 
         this.project.afterEvaluate {
             this.config.variant = new VariantBuilder( this.config ).build()
-            configureSetupTask()
-            configureNpmSetupTask()
-            configureYarnSetupTask()
+
+            // for root project the dependency to the root setup tasks will perform the setup and
+            // the tasks here will remain disabled
+            if( !hasRoot() ) {
+                configureSetupTask()
+                configureNpmSetupTask()
+                configureYarnSetupTask()
+            }
         }
     }
 
@@ -51,6 +56,11 @@ class NodePlugin
         addGlobalTaskType( YarnTask )
     }
 
+    private boolean hasRoot()
+    {
+        return this.project.parent != null && this.project.rootProject.hasProperty( NodeExtension.NAME)
+    }
+
     private void addTasks()
     {
         this.project.tasks.create( NpmInstallTask.NAME, NpmInstallTask )
@@ -58,6 +68,12 @@ class NodePlugin
         this.setupTask = this.project.tasks.create( SetupTask.NAME, SetupTask )
         this.npmSetupTask = this.project.tasks.create( NpmSetupTask.NAME, NpmSetupTask )
         this.yarnSetupTask = this.project.tasks.create( YarnSetupTask.NAME, YarnSetupTask )
+
+        if( hasRoot() ){
+            this.setupTask.dependsOn( this.project.rootProject.tasks.getByName( SetupTask.NAME ) )
+            this.npmSetupTask.dependsOn( this.project.rootProject.tasks.getByName( NpmSetupTask.NAME ) )
+            this.yarnSetupTask.dependsOn( this.project.rootProject.tasks.getByName( YarnSetupTask.NAME ) )
+        }
     }
 
     private void addGlobalTaskType( Class type )


### PR DESCRIPTION
task, gulp, grunt plugins check whether the same plugins were applied to root project. If so they inherit the configuration and make use of that download directory. The actual setup tasks then depend on the root setup tasks and do nothing on their own anymore.