### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: groovy
 sudo: false
+before_install:
+# Workaround to using OpenJDK 7 with Gradle due to security issue:
+# https://github.com/gradle/gradle/issues/2421
+- BCPROV_FILENAME=bcprov-ext-jdk15on-158.jar
+- wget "https://bouncycastle.org/download/${BCPROV_FILENAME}"
+- sudo mv $BCPROV_FILENAME /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/ext
+- sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
+- echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security
 
 cache:
   directories:
     - $HOME/.gradle
 
 jdk:
-- oraclejdk7
+- openjdk7
 
 script:
 - ./gradlew ci


### PR DESCRIPTION
The build on Travis is failing because Travis switched from Ubuntu Precise images to Ubuntu Trusty images. The Trusty images don't have installed Oracle JDK 7. See travis-ci/travis-ci#7884 This pull request uses OpenJDK 7 instead.