### PR TITLE
Fix race condition with parallel execution

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -3,7 +3,6 @@ package com.moowork.gradle.node.task
 import com.moowork.gradle.node.NodeExtension
 import com.moowork.gradle.node.variant.Variant
 import org.gradle.api.DefaultTask
-import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -24,8 +23,6 @@ class SetupTask
     protected Variant variant
 
     private IvyArtifactRepository repo
-
-    private List<ArtifactRepository> allRepos;
 
     SetupTask()
     {
@@ -78,7 +75,7 @@ class SetupTask
         deleteExistingNode()
         unpackNodeArchive()
         setExecutableFlag()
-        restoreRepositories()
+        removeRepository()
     }
 
     private void copyNodeExe()
@@ -170,10 +167,6 @@ class SetupTask
 
     private void addRepository()
     {
-        this.allRepos = new ArrayList<>()
-        this.allRepos.addAll( this.project.repositories )
-        this.project.repositories.clear()
-
         def distUrl = this.config.distBaseUrl
         this.repo = this.project.repositories.ivy {
             url distUrl
@@ -184,9 +177,8 @@ class SetupTask
         }
     }
 
-    private void restoreRepositories()
+    private void removeRepository()
     {
-        this.project.repositories.clear();
-        this.project.repositories.addAll( this.allRepos );
+        project.repositories.remove(repo)
     }
 }


### PR DESCRIPTION
If another task executes in parallel and uses the project repositories,
there's a possible race condition where the other task only gets our
distBaseUrl repository. We should not wipe the repository list. Instead
only add and remove our distBaseUrl repository.