### PR TITLE
#294 Explicitly cast workingDir as a java.io.File object in afterEvaluate().

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/npm/NpmTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/npm/NpmTask.groovy
@@ -26,15 +26,16 @@ class NpmTask
         }
     }
 
-    void afterEvaluate(nodeModulesDir) {
+    void afterEvaluate(nodeModulesDir)
+    {
         if ( !this.runner.workingDir )
         {
             setWorkingDir( nodeModulesDir )
         }
 
-        if ( !this.runner.workingDir.exists() )
+        if ( ! ((this.runner.workingDir) as File).exists() )
         {
-            this.runner.workingDir.mkdirs();
+            ((this.runner.workingDir) as File).mkdirs()
         }
     }
 

--- a/src/test/groovy/com/moowork/gradle/node/npm/NpmTaskTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/npm/NpmTaskTest.groovy
@@ -76,4 +76,23 @@ class NpmTaskTest
         task.result.exitValue == 0
         1 * this.execSpec.setIgnoreExitValue( false )
     }
+
+    def "exec npm task (set workingDir String)"()
+    {
+        given:
+        this.props.setProperty( 'os.name', 'Linux' )
+        this.execSpec = Mock( ExecSpec )
+
+        def task = this.project.tasks.create( 'simple', NpmTask )
+        task.workingDir = 'testDir'
+
+        when:
+        this.project.evaluate()
+        task.exec()
+
+        then:
+        task.result.exitValue == 0
+        1 * this.execSpec.setWorkingDir( 'testDir' )
+    }
+
 }


### PR DESCRIPTION
I added a test case to show that setting workingDir to a string will break afterEvaluate() before making the fix. After the fix, all test cases pass.