### PR TITLE
Fix issue with GRADLE_METADATA

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -181,6 +181,9 @@ class SetupTask
                 artifact 'v[revision]/[artifact](-v[revision]-[classifier]).[ext]'
                 ivy 'v[revision]/ivy.xml'
             }
+            metadataSources {
+                artifact()
+            }
         }
     }
 


### PR DESCRIPTION
When the GRADLE_METADATA feature is enabled (e.g. by applying
the `cpp-application` plugin), a build fails to resolve the
Node distribution as a dependency. This patch fixes this issue
using explicitly specified metadata sources.

See details: https://github.com/gradle/gradle/issues/5008