### PR TITLE
Relativize symlink to npmScriptFile

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -135,7 +135,9 @@ class SetupTask
             Path npm = Paths.get( variant.nodeBinDir.path, 'npm' )
             if ( Files.deleteIfExists( npm ) )
             {
-                Files.createSymbolicLink( npm, Paths.get( variant.npmScriptFile ) )
+                Files.createSymbolicLink(
+                        npm,
+                        variant.nodeBinDir.toPath().relativize(Paths.get(variant.npmScriptFile)))
             }
         }
     }


### PR DESCRIPTION
This way the downloaded node install can also be used where the
filesystem mapping is different, eg. in a docker container.