### PR TITLE
Fixed issue where npmVersion is ignored

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
@@ -29,7 +29,7 @@ class VariantBuilder
         variant.windows = platformHelper.isWindows()
 
         variant.nodeDir = getNodeDir( osName, osArch )
-        variant.npmDir = ext.npmVersion ? getNpmDir() : variant.nodeDir
+        variant.npmDir = this.ext.npmVersion ? getNpmDir() : variant.nodeDir
         variant.yarnDir = getYarnDir()
 
         variant.nodeBinDir = variant.nodeDir


### PR DESCRIPTION
Right now when I specify an npmVersion and set download = true the npmVersion I specified is being installed but not being used by NpmTasks.  Instead, the npm bundled with the node setup is used.

I think the npmVersion is always getting resolved to null in the conditional.

```
node {
	npmVersion = '5.8.0'
	download = true
}
```
```
task printNpmConfigInfo(type: NpmTask) {
 args = ['config', 'list']
}
```

When running with the above the configured npm run is 6.5 located in the nodejs bin folder, not the defined npm.

```
user-agent = "npm/6.5.0 node/v6.9.1 darwin x64"

; node bin location = /.gradle/nodejs/node-v6.9.1-darwin-x64/bin/node
```