### PR TITLE
fix npx symlink creation

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -131,13 +131,17 @@ class SetupTask
                 from this.project.tarTree( getNodeArchiveFile() )
                 into getNodeDir().parent
             }
-            // Fix broken symlink
-            Path npm = Paths.get( variant.nodeBinDir.path, 'npm' )
-            if ( Files.deleteIfExists( npm ) )
-            {
-                Files.createSymbolicLink(
-                        npm,
-                        variant.nodeBinDir.toPath().relativize(Paths.get(variant.npmScriptFile)))
+            // Fix broken symlinks
+            List symlinksToFix  = ['npm', 'npx']
+            symlinksToFix.each { link ->
+                Path linkPath = Paths.get( variant.nodeBinDir.path, link )
+                if ( Files.deleteIfExists( linkPath ) )
+                {
+                    Files.createSymbolicLink(
+                            linkPath,
+                            variant.nodeBinDir.toPath().relativize(Paths.get(variant."${link}ScriptFile"))
+                    )
+                }
             }
         }
     }

--- a/src/main/groovy/com/moowork/gradle/node/variant/Variant.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/Variant.groovy
@@ -10,6 +10,8 @@ class Variant
 
     def String npmScriptFile
 
+    def String npxScriptFile
+
     def File nodeDir
 
     def File nodeBinDir

--- a/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
@@ -59,6 +59,7 @@ class VariantBuilder
                 variant.exeDependency = getExeDependency()
             }
             variant.npmScriptFile = new File( variant.nodeDir , 'node_modules/npm/bin/npm-cli.js')
+            variant.npxScriptFile = new File( variant.nodeDir , 'node_modules/npm/bin/npx-cli.js')
         }
         else
         {
@@ -67,6 +68,7 @@ class VariantBuilder
             variant.yarnBinDir = new File( variant.yarnBinDir, 'bin' )
             variant.archiveDependency = getArchiveDependency( osName, osArch, 'tar.gz' )
             variant.npmScriptFile = new File( variant.nodeDir , 'lib/node_modules/npm/bin/npm-cli.js')
+            variant.npxScriptFile = new File( variant.nodeDir , 'lib/node_modules/npm/bin/npx-cli.js')
         }
 
         if (this.ext.download)

--- a/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
@@ -52,6 +52,7 @@ class VariantBuilderTest
           variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
           variant.nodeExec.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node.exe")
           variant.npmScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules${PS}npm${PS}bin${PS}npm-cli.js")
+          variant.npxScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules${PS}npm${PS}bin${PS}npx-cli.js")
 
         where:
           osArch   | nodeDir                    | exeDependency
@@ -86,6 +87,7 @@ class VariantBuilderTest
           variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
           variant.nodeExec.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node.exe")
           variant.npmScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules${PS}npm${PS}bin${PS}npm-cli.js")
+          variant.npxScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules${PS}npm${PS}bin${PS}npx-cli.js")
 
         where:
           osArch   | nodeDir                   | exeDependency
@@ -122,6 +124,8 @@ class VariantBuilderTest
           variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
           variant.nodeExec.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node.exe")
           variant.npmScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules${PS}npm${PS}bin${PS}npm-cli.js")
+          variant.npxScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "node_modules${PS}npm${PS}bin${PS}npx-cli.js")
+
         where:
           version | osArch
           "4.5.0" | "win-x86"
@@ -158,6 +162,7 @@ class VariantBuilderTest
           variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + 'bin')
           variant.nodeExec.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "bin${PS}node")
           variant.npmScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "lib${PS}node_modules${PS}npm${PS}bin${PS}npm-cli.js")
+          variant.npxScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "lib${PS}node_modules${PS}npm${PS}bin${PS}npx-cli.js")
 
         where:
           osName     | osArch   | nodeDir                   | depName
@@ -199,6 +204,7 @@ class VariantBuilderTest
           variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + 'bin')
           variant.nodeExec.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "bin${PS}node")
           variant.npmScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "lib${PS}node_modules${PS}npm${PS}bin${PS}npm-cli.js")
+          variant.npxScriptFile.toString().endsWith(NODE_BASE_PATH + nodeDir + PS + "lib${PS}node_modules${PS}npm${PS}bin${PS}npx-cli.js")
 
         where:
           osName  | osArch | sysOsArch | nodeDir                    | depName


### PR DESCRIPTION
When gradle installs on linux/mac, it seems the npm and npx symlinks were not correct. Code in SetupTask had been added to solve it for npm. This change simply adds support for npx as well.

In our package.json, we have a script that used npx as that's the only way a tool we're using advertises that we can run certain commands.

    `"build-something" : "npx sencha app build"`

Without this PR, `npx` is an empty file that does nothing. With this fix, we can use our `npx` package.json scripts from gradle NpmTask. 
