### PR TITLE
Add npmRegistry as first class citizen node config parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - $HOME/.gradle
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 script:
 - ./gradlew ci --stacktrace

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,17 +31,3 @@ This can be done adding some arguments to the already defined `npmInstall`-task.
 ```gradle
 npmInstall.args = ['--loglevel', 'silly']
 ```
-
-# How do I specify a registry for the NPM setup task?
-
-This can be done by adding to the arguments for the already defined `npmSetup` task.
-
-```gradle
-tasks.npmSetup {
-    doFirst {
-        args = args + ['--registry', 'http://myregistry.npm.com']
-    }
-}
-```
-
-You can also add any other arguments to this list that work with `npm install` i.e. more verbose modes.

--- a/docs/node.md
+++ b/docs/node.md
@@ -179,6 +179,9 @@ node {
   // Base URL for fetching node distributions (change if you have a mirror).
   distBaseUrl = 'https://nodejs.org/dist'
 
+  // Registry to use for yarn or npm
+  npmRegistry = 'http://myregistry.npm.com'
+
   // If true, it will download node using above parameters.
   // If false, it will try to use globally installed node.
   download = true

--- a/examples/simple-yarn/build.gradle
+++ b/examples/simple-yarn/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.moowork.node'
 
 node {
     download = true
+    npmRegistry = 'https://registry.npmjs.org/'
 }
 
 task helloWorld( type: NodeTask, dependsOn: 'yarn' ) {

--- a/src/main/groovy/com/moowork/gradle/node/NodeExtension.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/NodeExtension.groovy
@@ -11,6 +11,8 @@ class NodeExtension
 
     File npmWorkDir
 
+    String npmRegistry = 'https://registry.npmjs.org'
+
     File yarnWorkDir
 
     File nodeModulesDir

--- a/src/main/groovy/com/moowork/gradle/node/npm/NpmSetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/npm/NpmSetupTask.groovy
@@ -43,6 +43,7 @@ class NpmSetupTask
         set.add( getConfig().download )
         set.add( getConfig().npmVersion )
         set.add( getConfig().npmWorkDir )
+        set.add( getConfig().npmRegistry )
         return set
     }
 
@@ -109,7 +110,7 @@ class NpmSetupTask
         if ( !npmVersion.isEmpty() )
         {
             logger.debug( "Setting npmVersion to ${npmVersion}" )
-            setArgs( ['install', '--global', '--no-save', '--prefix', getVariant().npmDir, "npm@${npmVersion}"] )
+            setArgs( ['install', '--global', '--no-save', '--registry', getVariant().npmRegistry, '--prefix', getVariant().npmDir, "npm@${npmVersion}"] )
             enabled = true
         }
     }

--- a/src/main/groovy/com/moowork/gradle/node/variant/Variant.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/Variant.groovy
@@ -18,6 +18,8 @@ class Variant
 
     def String npmExec
 
+    def String npmRegistry
+
     def File npmDir
 
     def File npmBinDir

--- a/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/variant/VariantBuilder.groovy
@@ -30,6 +30,7 @@ class VariantBuilder
 
         variant.nodeDir = getNodeDir( osName, osArch )
         variant.npmDir = ext.npmVersion ? getNpmDir() : variant.nodeDir
+        variant.npmRegistry = ext.npmRegistry
         variant.yarnDir = getYarnDir()
 
         variant.nodeBinDir = variant.nodeDir
@@ -118,7 +119,7 @@ class VariantBuilder
         }
     }
 
-    //https://github.com/nodejs/node/pull/5995    
+    //https://github.com/nodejs/node/pull/5995
     private boolean hasWindowsZip()
     {
         def version = this.ext.version

--- a/src/main/groovy/com/moowork/gradle/node/yarn/YarnSetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/yarn/YarnSetupTask.groovy
@@ -26,6 +26,7 @@ class YarnSetupTask
         def set = new HashSet<>()
         set.add( this.getConfig().download )
         set.add( this.getConfig().yarnVersion )
+        set.add( this.getConfig().npmRegistry )
         return set
     }
 
@@ -45,7 +46,7 @@ class YarnSetupTask
             pkg += "@${yarnVersion}"
         }
 
-        this.setArgs( ['install', '--global', '--no-save', '--prefix', this.getVariant().yarnDir, pkg] )
+        this.setArgs( ['install', '--global', '--no-save', '--registry', getVariant().npmRegistry, '--prefix', this.getVariant().yarnDir, pkg] )
         enabled = true
     }
 }

--- a/src/test/groovy/com/moowork/gradle/node/NodeExtensionTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/NodeExtensionTest.groovy
@@ -18,6 +18,7 @@ class NodeExtensionTest
         ext.workDir != null
         ext.nodeModulesDir != null
         ext.version == '10.15.3'
+        ext.npmRegistry == 'https://registry.npmjs.org'
         !ext.download
         ext.npmVersion == ''
     }

--- a/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/node/variant/VariantBuilderTest.groovy
@@ -37,6 +37,7 @@ class VariantBuilderTest
           def ext = new NodeExtension(project)
           ext.download = true
           ext.version = '0.11.1'
+          ext.npmRegistry = 'http://myregistry.npm.com'
           ext.workDir = new File('.gradle/node').absoluteFile
 
           def builder = new VariantBuilder(ext)
@@ -47,6 +48,7 @@ class VariantBuilderTest
           variant.windows
           variant.exeDependency == exeDependency
           variant.archiveDependency == 'org.nodejs:node:0.11.1:linux-x86@tar.gz'
+          variant.npmRegistry == 'http://myregistry.npm.com'
 
           variant.nodeDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
           variant.nodeBinDir.toString().endsWith(NODE_BASE_PATH + nodeDir)
@@ -92,7 +94,7 @@ class VariantBuilderTest
           'x86'    | 'node-v4.0.0-win-x86' | 'org.nodejs:win-x86/node:4.0.0@exe'
           'x86_64' | 'node-v4.0.0-win-x64' | 'org.nodejs:win-x64/node:4.0.0@exe'
     }
-    
+
     @Unroll
     def "test variant on windows without exe (#osArch)"()
     {


### PR DESCRIPTION
I was struggling the whole day trying to configure a specific npm registry in my build file (written in kotlin DSL) by following the instruction of the FAQ (written in Groovy DSL).

At the end, I'm wondering if this setting could deserve to be an official setting for the gradle-node-plugin.

In this PR, i just added the variable npmRegistry and updated the documentation accordingly. 

Now, specifying an npm registry is as simple as this:
```
node {
   npmRegistry = 'https://myregistry.npm.com'
}
```

Do you think this PR could make sense?
Thanks in advance for your time.