### PR TITLE
Added support for Gradle 6.+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - $HOME/.gradle
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 script:
 - ./gradlew ci --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ group = 'com.moowork.gradle'
 
 apply plugin: 'idea'
 apply plugin: 'groovy'
-apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'java-gradle-plugin'
 apply from: "$rootDir/gradle/additional-artifacts.gradle"
@@ -28,10 +27,10 @@ configurations {
 }
 
 dependencies {
-    compile gradleApi()
-    testCompile 'cglib:cglib-nodep:3.2.4'
-    testCompile 'org.apache.commons:commons-io:1.3.2'
-    testCompile( 'org.spockframework:spock-core:1.0-groovy-2.4' ) {
+    implementation gradleApi()
+    testImplementation 'cglib:cglib-nodep:3.2.4'
+    testImplementation 'org.apache.commons:commons-io:1.3.2'
+    testImplementation( 'org.spockframework:spock-core:1.0-groovy-2.4' ) {
         exclude group: 'org.codehaus.groovy'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ repositories {
 }
 
 configurations {
-    integTestCompile.extendsFrom testCompile
-    integTestRuntime.extendsFrom testRuntime
+    integTestCompile.extendsFrom testCompileClasspath
+    integTestRuntime.extendsFrom testRuntimeClasspath
 }
 
 dependencies {

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -7,5 +7,5 @@ repositories {
 
 dependencies {
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.0'
+    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.9.9'
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'com.jfrog.bintray'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip

--- a/src/main/groovy/com/moowork/gradle/node/npm/NpmSetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/npm/NpmSetupTask.groovy
@@ -21,6 +21,7 @@ class NpmSetupTask
 
     private NodeExtension config
 
+    @Internal
     protected List<?> args = []
 
     private ExecResult result
@@ -81,7 +82,6 @@ class NpmSetupTask
         return this.args
     }
 
-    @Internal
     void setArgs( final Iterable<?> value )
     {
         this.args = value.toList()

--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -193,6 +193,9 @@ class SetupTask
                     artifact 'v[revision]/[artifact](-v[revision]-[classifier]).[ext]'
                     ivy 'v[revision]/ivy.xml'
                 }
+                metadataSources {
+                    artifact()
+                }
             }
         }
     }

--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -185,6 +185,9 @@ class SetupTask
                     artifact 'v[revision]/[artifact](-v[revision]-[classifier]).[ext]'
                     ivy 'v[revision]/ivy.xml'
                 }
+                metadataSources {
+                    artifact()
+                }
             }
         } else {
             this.repo = this.project.repositories.ivy {

--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -9,6 +9,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.util.GradleVersion
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -177,11 +178,21 @@ class SetupTask
         this.project.repositories.clear()
 
         def distUrl = this.config.distBaseUrl
-        this.repo = this.project.repositories.ivy {
-            url distUrl
-            layout 'pattern', {
-                artifact 'v[revision]/[artifact](-v[revision]-[classifier]).[ext]'
-                ivy 'v[revision]/ivy.xml'
+        if(GradleVersion.current().baseVersion >= GradleVersion.version('5.0').baseVersion) {
+            this.repo = this.project.repositories.ivy {
+                url distUrl
+                patternLayout {
+                    artifact 'v[revision]/[artifact](-v[revision]-[classifier]).[ext]'
+                    ivy 'v[revision]/ivy.xml'
+                }
+            }
+        } else {
+            this.repo = this.project.repositories.ivy {
+                url distUrl
+                layout 'pattern', {
+                    artifact 'v[revision]/[artifact](-v[revision]-[classifier]).[ext]'
+                    ivy 'v[revision]/ivy.xml'
+                }
             }
         }
     }


### PR DESCRIPTION
Gradle 6 is around the corner and there are multiple deprecations that need to be addresses in order to work with it. This PR fixes the following:

* Remove usage of `maven` plugin
```
The maven plugin has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the maven-publish plugin instead.
```

*Upgrade artifactory plugin to stop using non-existing Gradle's internal APIs

```
Caused by: java.lang.NoSuchMethodError: org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal.getPublishableFiles()Lorg/gradle/api/file/FileCollection;
        at org.jfrog.gradle.plugin.artifactory.task.helper.TaskHelperPublications.checkDependsOnArtifactsToPublish(TaskHelperPublications.java:140)
        at org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask.checkDependsOnArtifactsToPublish(ArtifactoryTask.java:55)
        at org.jfrog.gradle.plugin.artifactory.task.BuildInfoBaseTask.projectsEvaluated(BuildInfoBaseTask.java:189)
        at org.jfrog.gradle.plugin.artifactory.task.BuildInfoBaseTask$projectsEvaluated.call(Unknown Source)
        at org.jfrog.gradle.plugin.artifactory.extractor.listener.ProjectsEvaluatedBuildListener$_afterEvaluate_closure1.doCall(ProjectsE
```

* Move to `implementation` and `testImplementation` configurations

```
The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the implementation or api configuration instead.
        at build_ao06dlp02sqp83bf447p0wztv$_run_closure3.doCall(/Users/rperezalcolea/Projects/github/srs/gradle-node-plugin/build.gradle:31)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The testCompile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the testImplementation configuration instead.
        at build_ao06dlp02sqp83bf447p0wztv$_run_closure3.doCall(/Users/rperezalcolea/Projects/github/srs/gradle-node-plugin/build.gradle:32)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```


* Annotate tasks properly. `validateTaskProperties` will fail builds on Gradle 6.0

```
Task property validation finished with warnings:
  - Warning: Type 'com.moowork.gradle.node.npm.NpmSetupTask': property 'args' is not annotated with an input or output annotation.
  - Warning: Type 'com.moowork.gradle.node.npm.NpmSetupTask': setter method 'setArgs()' should not be annotated with: @Internal
  - Warning: Type 'com.moowork.gradle.node.yarn.YarnSetupTask': property 'args' is not annotated with an input or output annotation.
```

* Use `patternLayout` instead of `layout 'pattern'` which is removed on Gradle 6.0. Kept backwards compatibility here.

```
The IvyArtifactRepository.layout(String, Closure) method has been deprecated. This is scheduled to be removed in Gradle 6.0. Please use the IvyArtifactRepository.patternLayout(Action) method instead.
        at org.gradle.api.internal.artifacts.repositories.DefaultIvyArtifactRepository.layout(DefaultIvyArtifactRepository.java:302)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:326)
        at org.gradle.internal.extensibility.MixInClosurePropertiesAsMethodsDynamicObject.tryInvokeMethod(MixInClosurePropertiesAsMethodsDynamicObject.java:33)
        at com.moowork.gradle.node.task.SetupTask$_addRepository_closure5.doCall(SetupTask.groovy:164)
``` 